### PR TITLE
Feature/#6

### DIFF
--- a/cmd/etl/main.go
+++ b/cmd/etl/main.go
@@ -56,6 +56,11 @@ func main() {
 			Counter:            0,
 			DoneChannel:        make(chan bool),
 		},
+		service.PROCESS_CRIMES_AMOUNT_PER_PERIOD_QUEUE_NAME: {
+			ServiceConstructor: service.NewCountCrimesAmountPerPeriodService,
+			Counter:            0,
+			DoneChannel:        make(chan bool),
+		},
 	}
 
 	for queueName := range consumersMap {

--- a/internal/app/service/count_crimes_amount_per_period.go
+++ b/internal/app/service/count_crimes_amount_per_period.go
@@ -1,0 +1,73 @@
+package service
+
+import (
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/caiogmrocha/etl-los-angeles-criminal-data-backend/internal/domain/entity"
+	"github.com/caiogmrocha/etl-los-angeles-criminal-data-backend/pkg/utils"
+)
+
+type CountCrimesAmountPerPeriodService struct{}
+
+type CountCrimesAmountPerPeriodDataYear map[string]int
+
+type CountCrimesAmountPerPeriodData map[string](CountCrimesAmountPerPeriodDataYear)
+
+const (
+	CRIMES_AMOUNT_PER_PERIOD_OUTPUT_KEY         = "crimes_amount_per_period"
+	PROCESS_CRIMES_AMOUNT_PER_PERIOD_QUEUE_NAME = "process.crimes-amount-per-period"
+)
+
+func (s *CountCrimesAmountPerPeriodService) Execute(output *sync.Map, record *entity.Record) {
+	var crimesAmountPerPeriodData *CountCrimesAmountPerPeriodData
+
+	value, ok := output.Load(CRIMES_AMOUNT_PER_PERIOD_OUTPUT_KEY)
+
+	if !ok {
+		crimesAmountPerPeriodData = &CountCrimesAmountPerPeriodData{}
+
+		for i := 2020; i <= 2024; i++ {
+			(*crimesAmountPerPeriodData)[strconv.Itoa(i)] = CountCrimesAmountPerPeriodDataYear{}
+
+			for j := 1; j <= 12; j++ {
+				(*crimesAmountPerPeriodData)[strconv.Itoa(i)][strconv.Itoa(j)] = 0
+			}
+		}
+	} else {
+		crimesAmountPerPeriodData = value.(*CountCrimesAmountPerPeriodData)
+	}
+
+	period, err := time.Parse("01/02/2006 03:04:05 PM", record.DATEOCC)
+
+	if err != nil {
+		period, err = time.Parse("01/02/2006 03:04:05", record.DATEOCC)
+
+		if err != nil {
+			utils.FailOnError(err, "Error parsing date")
+		}
+	}
+
+	year := period.Year()
+	month := int(period.Month())
+
+	switch {
+	case year == 2020:
+		(*crimesAmountPerPeriodData)["2020"][strconv.Itoa(month)]++
+	case year == 2021:
+		(*crimesAmountPerPeriodData)["2021"][strconv.Itoa(month)]++
+	case year == 2022:
+		(*crimesAmountPerPeriodData)["2022"][strconv.Itoa(month)]++
+	case year == 2023:
+		(*crimesAmountPerPeriodData)["2023"][strconv.Itoa(month)]++
+	case year == 2024:
+		(*crimesAmountPerPeriodData)["2024"][strconv.Itoa(month)]++
+	}
+
+	output.Store(CRIMES_AMOUNT_PER_PERIOD_OUTPUT_KEY, crimesAmountPerPeriodData)
+}
+
+func NewCountCrimesAmountPerPeriodService() Service {
+	return &CountCrimesAmountPerPeriodService{}
+}

--- a/internal/app/service/count_crimes_amount_per_period_test.go
+++ b/internal/app/service/count_crimes_amount_per_period_test.go
@@ -1,0 +1,92 @@
+package service
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/caiogmrocha/etl-los-angeles-criminal-data-backend/internal/domain/entity"
+)
+
+func TestCountCrimesAmountPerPeriodService_Execute_Success(t *testing.T) {
+	// Arrange
+	service := NewCountCrimesAmountPerPeriodService()
+
+	syncMap := &sync.Map{}
+
+	// Act
+	service.Execute(syncMap, recordWithPeriodMockFactory("01/01/2021 00:00:00 AM"))
+	service.Execute(syncMap, recordWithPeriodMockFactory("01/01/2021 00:00:00 AM"))
+	service.Execute(syncMap, recordWithPeriodMockFactory("01/01/2022 00:00:00 AM"))
+
+	value, ok := syncMap.Load(CRIMES_AMOUNT_PER_PERIOD_OUTPUT_KEY)
+
+	// Assert
+	if !ok {
+		t.Errorf("Expected to have a value in key %s of syncMap", CRIMES_AMOUNT_PER_PERIOD_OUTPUT_KEY)
+	}
+
+	crimesAmountPerPeriodData := value.(*CountCrimesAmountPerPeriodData)
+
+	assertionsMap := map[string]map[string]int{
+		"2020": {
+			"1": 0, "2": 0, "3": 0, "4": 0, "5": 0, "6": 0, "7": 0, "8": 0, "9": 0, "10": 0, "11": 0, "12": 0,
+		},
+		"2021": {
+			"1": 2, "2": 0, "3": 0, "4": 0, "5": 0, "6": 0, "7": 0, "8": 0, "9": 0, "10": 0, "11": 0, "12": 0,
+		},
+		"2022": {
+			"1": 1, "2": 0, "3": 0, "4": 0, "5": 0, "6": 0, "7": 0, "8": 0, "9": 0, "10": 0, "11": 0, "12": 0,
+		},
+		"2023": {
+			"1": 0, "2": 0, "3": 0, "4": 0, "5": 0, "6": 0, "7": 0, "8": 0, "9": 0, "10": 0, "11": 0, "12": 0,
+		},
+		"2024": {
+			"1": 0, "2": 0, "3": 0, "4": 0, "5": 0, "6": 0, "7": 0, "8": 0, "9": 0, "10": 0, "11": 0, "12": 0,
+		},
+	}
+
+	for year, months := range *crimesAmountPerPeriodData {
+		for month, amount := range months {
+			expectedAmount := assertionsMap[year][month]
+
+			if amount != expectedAmount {
+				t.Errorf("Expected crimesAmountPerPeriodData[%s][%s] to be %d, got %d", year, month, expectedAmount, amount)
+			}
+		}
+	}
+}
+
+func recordWithPeriodMockFactory(period string) *entity.Record {
+	recordMock := &entity.Record{
+		DR_NO:        "123",
+		DateRptd:     "2021-01-01",
+		DATEOCC:      period,
+		TIMEOCC:      "00:00",
+		AREA:         "01",
+		AREANAME:     "Central",
+		RptDistNo:    "0100",
+		Part12:       "12",
+		CrmCd:        "123",
+		CrmCdDesc:    "Theft",
+		Mocodes:      "123",
+		VictAge:      "30",
+		VictSex:      "M",
+		VictDescent:  "H",
+		PremisCd:     "123",
+		PremisDesc:   "House",
+		WeaponUsedCd: "123",
+		WeaponDesc:   "Gun",
+		Status:       "123",
+		StatusDesc:   "123",
+		CrmCd1:       "123",
+		CrmCd2:       "123",
+		CrmCd3:       "123",
+		CrmCd4:       "123",
+		LOCATION:     "123",
+		CrossStreet:  "123",
+		LAT:          "123",
+		LON:          "123",
+	}
+
+	return recordMock
+}

--- a/internal/app/service/produce_processing_tasks.go
+++ b/internal/app/service/produce_processing_tasks.go
@@ -48,6 +48,10 @@ func (s *ProduceProcessingTasksService) Execute(ctx context.Context, databasePat
 			QueueName:  PROCESS_CRIMES_AMOUNT_PER_AREA_QUEUE_NAME,
 			RoutingKey: PROCESS_CRIMES_DATA_ROUTING_KEY,
 		},
+		{
+			QueueName:  PROCESS_CRIMES_AMOUNT_PER_PERIOD_QUEUE_NAME,
+			RoutingKey: PROCESS_CRIMES_DATA_ROUTING_KEY,
+		},
 	}
 
 	for _, queue := range queuesToBind {


### PR DESCRIPTION
Release:

- criar service CountCrimesAmountPerGeolocationService
- criar testes para o service CountCrimesAmountPerGeolocationService
- criar exchange do tipo direct para a routing key process.crimes-amount-per-geolocation.
- criar queue para a exchange criada.
- criar consumer para a queue criada.
- garantir que o consumer armazene o output em /assets/output.json